### PR TITLE
docs: fix fontfamily config

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ import { theme } from "#tailwind-config";
 const themeConfig: ThemeConfig = {
   shared: {
     common: {
-      fontFamily: theme.fontFamily.sans,
+      fontFamily: theme.fontFamily.sans.join(", "),
       lineHeight: theme.lineHeight.normal,
     },
   },


### PR DESCRIPTION
The tailwind config exposes the fontfamily as an array of font names but naive ui expects a comma-separated string, see https://www.naiveui.com/en-US/os-theme/docs/theme.