### PR TITLE
fix: don't try to display icon if name is wrong

### DIFF
--- a/src/runtime/components/NaiveIcon.vue
+++ b/src/runtime/components/NaiveIcon.vue
@@ -1,5 +1,5 @@
 <template>
-    <n-icon-wrapper :size="sSize" :border-radius="borderRadius" :color="color" :icon-color="iconColor">
+    <n-icon-wrapper v-if="icon" :size="sSize" :border-radius="borderRadius" :color="color" :icon-color="iconColor">
         <Icon :icon="icon" :width="sSize" :height="sSize" />
     </n-icon-wrapper>
 </template>


### PR DESCRIPTION
If `loadIcon` cannot find the icon based on the name passed to it, `icon` is `void`. In this case, we no longer try to display the icon.

(it's actually only a cosmetic thing, mostly triggered by nuxi complaining about types where `Icon` needs to be passed something and not void)