### PR TITLE
build(icons): allow setting custom collections url

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -41,8 +41,7 @@ export default defineNuxtModule<ModuleOptions>({
     colorModePreferenceCookieName: "naive_color_mode_preference",
     iconSize: 20,
     iconDownload: false,
-    // This is a proxy to solve blocked `raw.githubusercontent.com` in China
-    iconCollectionsUrl: 'https://iconify-icon-sets.vercel.app',
+    iconCollectionsUrl: 'https://raw.githubusercontent.com/iconify/icon-sets/master/collections.json',
     themeConfig: {},
   },
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -41,6 +41,8 @@ export default defineNuxtModule<ModuleOptions>({
     colorModePreferenceCookieName: "naive_color_mode_preference",
     iconSize: 20,
     iconDownload: false,
+    // This is a proxy to solve blocked `raw.githubusercontent.com` in China
+    iconCollectionsUrl: 'https://iconify-icon-sets.vercel.app',
     themeConfig: {},
   },
 
@@ -185,11 +187,8 @@ export default defineNuxtModule<ModuleOptions>({
     // https://github.com/becem-gharbi/iconify-offline-nuxt
     if (options?.iconDownload) {
       extendViteConfig((config) => {
-        // This is a proxy to solve blocked `raw.githubusercontent.com` in China
-        const collectionsUrl = 'https://iconify-icon-sets.vercel.app'
-
         config.plugins ||= []
-        config.plugins.push(iconifyVitePlugin(nuxt.options.rootDir, collectionsUrl))
+        config.plugins.push(iconifyVitePlugin(nuxt.options.rootDir, options?.iconCollectionsUrl))
       })
     }
   },

--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -41,6 +41,7 @@ export interface PublicConfig {
   colorModePreferenceCookieName: string;
   iconSize: number;
   iconDownload: boolean;
+  iconCollectionsUrl: string;
 }
 
 declare module 'nuxt/schema' {


### PR DESCRIPTION
I'm sorry to tell you, we can't access Vercel now, while GitHub can sometimes be accessed with a terrible delay.

![Vercel - 100% timeout](https://github.com/becem-gharbi/nuxt-naiveui/assets/145281501/bb3d5343-648f-4931-8dfd-9d079df3ff6b)
![GitHub - ~60% timeout](https://github.com/becem-gharbi/nuxt-naiveui/assets/145281501/f8c299fb-9111-42f3-badb-e3d9e7509278)

As policies are different across provinces and operators, a single solution for all is elusive. In these circumstances, it's simply best left for the user to self-select.