### PR TITLE
chore: support pnpm installation without `shamefully-hoist`

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "nuxt": "^3.10.0",
     "vitest": "^1.2.2"
   },
+  "peerDependencies": {
+    "naive-ui": "^2.37.3"
+  },
   "repository": {
     "url": "git+https://github.com/becem-gharbi/nuxt-naiveui.git"
   },

--- a/src/module.ts
+++ b/src/module.ts
@@ -167,11 +167,7 @@ export default defineNuxtModule<ModuleOptions>({
       extendViteConfig((config) => {
         config.optimizeDeps ||= {};
         config.optimizeDeps.include ||= [];
-        config.optimizeDeps.include.push(
-          "naive-ui",
-          "vueuc",
-          "date-fns-tz/formatInTimeZone"
-        );
+        config.optimizeDeps.include.push("naive-ui");
       });
     } else {
       nuxt.options.build.transpile.push(


### PR DESCRIPTION
A possible solution. Please critique if this is a bad design :)

- take `naive-ui` to the top level of `node_modules/` so that Vite can resolve it
- remove unnecessary dependency optimizations
  When optimizing `naive-ui` itself, dependencies such as `vueuc` will be inlined and optimized together. Therefore, there is no need to optimize them separately.

fix #48