### PR TITLE
feat(NaiveColorModeSwitch): support custom icons

### DIFF
--- a/docs/content/2.components/5.naive-color-mode-switch.md
+++ b/docs/content/2.components/5.naive-color-mode-switch.md
@@ -1,3 +1,12 @@
 # NaiveColorModeSwitch
 
-This component can be used to change colorMode preference. Its has `n-button` naive-ui component as root so [props](https://www.naiveui.com/en-US/os-theme/components/button) fallthrough.
+This component can be used to change colorMode preference.
+
+### Props
+
+| **Name**       | **Type**    | **Default**  | **Note**                                                                      |
+| -------------- | ----------- | ------------ | ----------------------------------------------------------------------------- |
+| Button's props | ButtonProps |              | Refer to [naive-ui](https://www.naiveui.com/en-US/os-theme/components/button) |
+| iconLight      | string      | `ph:sun`     | Icon name for light mode                                                      |
+| iconDark       | string      | `ph:moon`    | Icon name for dark mode                                                       |
+| iconSystem     | string      | `ph:monitor` | Icon name for system preference                                              |

--- a/src/runtime/components/NaiveColorModeSwitch.vue
+++ b/src/runtime/components/NaiveColorModeSwitch.vue
@@ -13,8 +13,16 @@
 import type { ButtonProps } from 'naive-ui'
 import { useNaiveColorMode, computed } from '#imports'
 
-interface Props extends /* @vue-ignore */ ButtonProps {}
-defineProps<Props>()
+interface Props extends /* @vue-ignore */ ButtonProps {
+  iconLight?: string;
+  iconDark?: string;
+  iconSystem?: string;
+}
+const props = withDefaults(defineProps<Props>(), {
+  iconLight: 'ph:sun',
+  iconDark: 'ph:moon',
+  iconSystem: 'ph:monitor'
+})
 
 const { colorModePreference } = useNaiveColorMode()
 
@@ -26,11 +34,11 @@ const preference = computed({
 const icon = computed(() => {
   switch (preference.value) {
     case 'light':
-      return 'ph:sun'
+      return props.iconLight
     case 'dark':
-      return 'ph:moon'
+      return props.iconDark
     case 'system':
-      return 'ph:monitor'
+      return props.iconSystem
     default:
       return 'ph:dots-three'
   }


### PR DESCRIPTION
Add props for `NaiveColorModeSwitch` to support custom icons.