### PR TITLE
feat: add color theme generator

### DIFF
--- a/docs/content/2.components/1.naive-config.md
+++ b/docs/content/2.components/1.naive-config.md
@@ -23,3 +23,19 @@ The common theme properties are shared globally via `useThemeVars` naive-ui comp
 ::alert{type="warning"}
 Naive UI generates CSS using JS [(reference)](https://www.npmjs.com/package/css-render). This implementation **may cause an issue on pre-rendered Nuxt pages** because they are static (generated at build time). Thus a hydration mismatch may occur in this case.
 ::
+
+### Customization
+
+To automatically generate color themes without granular customization, it's recommended to use `generateColorThemes` utility introduced in [#62](https://github.com/becem-gharbi/nuxt-naiveui/pull/62).
+
+```ts [app.config.ts]
+import { generateColorThemes } from "@bg-dev/nuxt-naiveui/utils";
+
+export default defineAppConfig({
+  naiveui: {
+    themeConfig: {
+      ...generateColorThemes({ primary: "#722ed1" }),
+    },
+  },
+});
+```

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
       "types": "./dist/types.d.ts",
       "import": "./dist/module.mjs",
       "require": "./dist/module.cjs"
+    },
+    "./utils": {
+      "types": "./dist/runtime/utils/index.d.ts",
+      "import": "./dist/runtime/utils/index.mjs"
     }
   },
   "main": "./dist/module.cjs",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "typecheck": "nuxi typecheck"
   },
   "dependencies": {
+    "@ant-design/colors": "^7.0.2",
     "@iconify/vue": "^4.1.1",
     "@nuxt/kit": "^3.11.1",
     "defu": "^6.1.4",

--- a/playground/app.config.ts
+++ b/playground/app.config.ts
@@ -1,30 +1,10 @@
-// @ts-nocheck
-
+import { generateColorThemes } from '../src/runtime/utils'
 import { defineAppConfig } from '#imports'
-import { _colors, _fontFamily } from '#tailwind-config/theme.mjs'
 
 export default defineAppConfig({
   naiveui: {
     themeConfig: {
-      shared: {
-        common: {
-          fontFamily: _fontFamily.sans.join(', ')
-        }
-      },
-      light: {
-        common: {
-          primaryColor: _colors.blue[600],
-          primaryColorHover: _colors.blue[500],
-          primaryColorPressed: _colors.blue[700]
-        }
-      },
-      dark: {
-        common: {
-          primaryColor: _colors.blue[500],
-          primaryColorHover: _colors.blue[400],
-          primaryColorPressed: _colors.blue[600]
-        }
-      }
+      ...generateColorThemes()
     }
   }
 })

--- a/src/runtime/theme/dark.ts
+++ b/src/runtime/theme/dark.ts
@@ -1,4 +1,4 @@
-import type { GlobalThemeOverrides } from 'naive-ui'
+import type { Theme } from '../types'
 
 export default {
   common: {
@@ -117,4 +117,4 @@ export default {
   Form: {
     feedbackPadding: '8px 0px 10px 0px'
   }
-} as GlobalThemeOverrides
+} as Theme

--- a/src/runtime/theme/light.ts
+++ b/src/runtime/theme/light.ts
@@ -1,4 +1,4 @@
-import type { GlobalThemeOverrides } from 'naive-ui'
+import type { Theme } from '../types'
 
 export default {
   common: {
@@ -61,4 +61,4 @@ export default {
   Form: {
     feedbackPadding: '8px 0px 10px 0px'
   }
-} as GlobalThemeOverrides
+} as Theme

--- a/src/runtime/theme/mobileOrTablet.ts
+++ b/src/runtime/theme/mobileOrTablet.ts
@@ -1,4 +1,4 @@
-import type { GlobalThemeOverrides } from 'naive-ui'
+import type { Theme } from '../types'
 
 export default {
   common: {
@@ -52,4 +52,4 @@ export default {
   Pagination: {
     itemSizeMedium: '36px'
   }
-} as GlobalThemeOverrides
+} as Theme

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -1,11 +1,15 @@
 import type { GlobalThemeOverrides } from "naive-ui";
 
+interface Theme extends GlobalThemeOverrides {
+  defaults?: boolean;
+}
+
 export interface ThemeConfig {
-  shared?: GlobalThemeOverrides;
-  light?: GlobalThemeOverrides & { defaults?: boolean };
-  dark?: GlobalThemeOverrides & { defaults?: boolean };
-  mobileOrTablet?: GlobalThemeOverrides & { defaults?: boolean };
-  mobile?: GlobalThemeOverrides & { defaults?: boolean };
+  shared?: Theme | (() => Theme);
+  light?: Theme | (() => Theme);
+  dark?: Theme | (() => Theme);
+  mobileOrTablet?: Theme | (() => Theme);
+  mobile?: Theme | (() => Theme);
 }
 
 export interface NavbarRoute {
@@ -27,9 +31,9 @@ interface RouteLocation {
   force?: boolean;
   hash?: string;
   name?: string | symbol;
-  params?: Record<string, any>,
+  params?: Record<string, any>;
   path?: string;
-  query?: Record<string, any>,
+  query?: Record<string, any>;
   replace?: boolean;
 }
 
@@ -38,8 +42,8 @@ export interface MenuLinkRoute {
   icon?: string;
   to?: string | RouteLocation;
   /**
-  * @deprecated since version 1.11.0, please use `to` instead
-  */
+   * @deprecated since version 1.11.0, please use `to` instead
+   */
   path?: string | RouteLocation;
   children?: MenuLinkRoute[];
 }
@@ -59,10 +63,10 @@ export interface PublicConfig {
   iconCollectionsUrl: string;
 }
 
-declare module 'nuxt/schema' {
+declare module "nuxt/schema" {
   interface AppConfigInput {
     naiveui?: {
       themeConfig?: ThemeConfig;
-    }
+    };
   }
 }

--- a/src/runtime/utils/colors.ts
+++ b/src/runtime/utils/colors.ts
@@ -15,6 +15,23 @@ interface PaletteOptions extends Colors {
   theme: ColorMode;
 }
 
+export function generateColorThemes (inputColors?: Partial<Colors>) {
+  const colors = {
+    primary: '#1677ff',
+    success: '#52c41a',
+    warning: '#faad14',
+    error: '#f5222d',
+    info: '#1677ff',
+    neutral: '#71717a',
+    ...inputColors
+  }
+
+  return {
+    light: generateColorTheme('light', colors),
+    dark: generateColorTheme('dark', colors)
+  }
+}
+
 function generatePalette (paletteOptions: PaletteOptions) {
   const gray = '#bfbfbf'
   const theme = paletteOptions.theme === 'light' ? 'default' : 'dark'
@@ -86,10 +103,10 @@ function generateColorTheme (mode: ColorMode = 'light', colors: Colors) {
       borderColor: palette.neutral[2],
 
       textColorBase: palette.text[9],
-      textColorDisabled: palette.text[6],
-      textColor1: palette.text[8],
-      textColor2: palette.text[7],
-      textColor3: palette.text[6],
+      textColorDisabled: palette.text[7],
+      textColor1: palette.text[9],
+      textColor2: palette.text[8],
+      textColor3: palette.text[7],
 
       placeholderColor: palette.text[5],
       placeholderColorDisabled: palette.text[5],
@@ -183,23 +200,9 @@ function generateColorTheme (mode: ColorMode = 'light', colors: Colors) {
       arrowColorChildActiveHoverInverted: palette.primary[5],
       arrowColorActiveInverted: palette.primary[6],
       arrowColorActiveHoverInverted: palette.primary[5]
+    },
+    Drawer: {
+      color: palette.neutral[0]
     }
   } as GlobalThemeOverrides
-}
-
-export function generateColorThemes (inputColors?: Partial<Colors>) {
-  const colors = {
-    primary: '#1677ff',
-    success: '#52c41a',
-    warning: '#faad14',
-    error: '#f5222d',
-    info: '#1677ff',
-    neutral: '#71717a',
-    ...inputColors
-  }
-
-  return {
-    light: generateColorTheme('light', colors),
-    dark: generateColorTheme('dark', colors)
-  }
 }

--- a/src/runtime/utils/colors.ts
+++ b/src/runtime/utils/colors.ts
@@ -27,8 +27,8 @@ export function generateColorThemes (inputColors?: Partial<Colors>) {
   }
 
   return {
-    light: generateColorTheme('light', colors),
-    dark: generateColorTheme('dark', colors)
+    light: () => generateColorTheme('light', colors),
+    dark: () => generateColorTheme('dark', colors)
   }
 }
 

--- a/src/runtime/utils/colors.ts
+++ b/src/runtime/utils/colors.ts
@@ -80,86 +80,19 @@ function generateColorThemeLight (colors: Colors) {
       errorColorSuppl: palette.error[8],
 
       bodyColor: palette.neutral[0],
-      cardColor: palette.neutral[0],
-      modalColor: palette.neutral[0],
-      inputColor: palette.neutral[0],
-      inputColorDisabled: palette.neutral[0],
-
-      tabColor: palette.neutral[1],
-      popoverColor: palette.neutral[1],
-      tagColor: palette.neutral[1],
-      baseColor: palette.neutral[1],
-      codeColor: palette.neutral[1],
-
-      dividerColor: palette.neutral[2],
-      avatarColor: palette.neutral[3],
-      hoverColor: palette.neutral[2],
-      actionColor: palette.neutral[1],
-      borderColor: palette.neutral[2],
 
       textColorBase: palette.text[9],
       textColorDisabled: palette.text[7],
       textColor1: palette.text[9],
       textColor2: palette.text[8],
-      textColor3: palette.text[6],
-
-      placeholderColor: palette.text[5],
-      placeholderColorDisabled: palette.text[5],
-
-      closeIconColor: palette.neutral[7],
-      closeIconColorHover: palette.neutral[6],
-      closeIconColorPressed: palette.neutral[6],
-      closeColorHover: palette.neutral[2],
-      closeColorPressed: palette.neutral[3],
-
-      clearColor: palette.neutral[7],
-      clearColorHover: palette.neutral[6],
-      clearColorPressed: palette.neutral[6],
-
-      scrollbarColor: palette.neutral[2],
-      scrollbarColorHover: palette.neutral[3],
-
-      progressRailColor: palette.neutral[2],
-      railColor: palette.neutral[2],
-
-      buttonColor2: palette.neutral[1],
-      buttonColor2Hover: palette.neutral[2],
-      buttonColor2Pressed: palette.neutral[3],
-
-      tableColor: palette.neutral[1],
-      tableHeaderColor: palette.neutral[1],
-      tableColorStriped: palette.neutral[1],
-      tableColorHover: palette.neutral[1]
-    },
-    Skeleton: {
-      color: palette.neutral[2],
-      colorEnd: palette.neutral[3]
-    },
-    Tag: {
-      colorBordered: palette.neutral[1]
-    },
-    Tooltip: {
-      color: palette.neutral[1],
-      textColor: palette.text[8]
-    },
-    Slider: {
-      indicatorColor: palette.neutral[1],
-      indicatorTextColor: palette.text[8]
+      textColor3: palette.text[6]
     },
     Layout: {
       siderColor: palette.neutral[0],
       headerColor: palette.neutral[0],
       footerColor: palette.neutral[0]
     },
-    Icon: {
-      color: palette.text[8]
-    },
-    Switch: {
-      railColor: palette.neutral[2]
-    },
-    Tabs: {
-      tabColorSegment: palette.neutral[0]
-    },
+
     Menu: {
       itemTextColorHorizontalInverted: palette.text[7],
       itemIconColorHorizontalInverted: palette.text[7],
@@ -236,7 +169,6 @@ function generateColorThemeDark (colors: Colors) {
 
       bodyColor: palette.neutral[0],
       cardColor: palette.neutral[0],
-      modalColor: palette.neutral[0],
       inputColor: palette.neutral[0],
       inputColorDisabled: palette.neutral[0],
 
@@ -245,6 +177,7 @@ function generateColorThemeDark (colors: Colors) {
       tagColor: palette.neutral[1],
       baseColor: palette.neutral[1],
       codeColor: palette.neutral[1],
+      modalColor: palette.neutral[1],
 
       dividerColor: palette.neutral[2],
       avatarColor: palette.neutral[3],
@@ -314,42 +247,6 @@ function generateColorThemeDark (colors: Colors) {
     },
     Tabs: {
       tabColorSegment: palette.neutral[0]
-    },
-    Menu: {
-      itemTextColorHorizontalInverted: palette.text[7],
-      itemIconColorHorizontalInverted: palette.text[7],
-
-      itemIconColorHoverHorizontalInverted: palette.text[8],
-      itemTextColorHoverHorizontalInverted: palette.text[8],
-
-      itemTextColorActiveHorizontalInverted: palette.text[9],
-      itemIconColorActiveHorizontalInverted: palette.text[9],
-
-      itemTextColorActiveHoverHorizontalInverted: palette.text[8],
-      itemIconColorActiveHoverHorizontalInverted: palette.text[8],
-
-      itemTextColorChildActiveHorizontalInverted: palette.text[9],
-      itemIconColorChildActiveHorizontalInverted: palette.text[9],
-
-      itemIconColorChildActiveHoverHorizontalInverted: palette.text[8],
-      itemTextColorChildActiveHoverHorizontalInverted: palette.text[8],
-
-      itemTextColorInverted: palette.text[8],
-      itemIconColorInverted: palette.text[8],
-      itemTextColorHoverInverted: palette.text[8],
-      itemIconColorHoverInverted: palette.text[8],
-
-      itemTextColorChildActiveHoverInverted: palette.primary[5],
-      itemTextColorChildActiveInverted: palette.primary[6],
-      itemIconColorChildActiveHoverInverted: palette.primary[5],
-      itemIconColorChildActiveInverted: palette.primary[6],
-
-      arrowColorInverted: palette.text[8],
-      arrowColorHoverInverted: palette.text[8],
-      arrowColorChildActiveInverted: palette.primary[6],
-      arrowColorChildActiveHoverInverted: palette.primary[5],
-      arrowColorActiveInverted: palette.primary[6],
-      arrowColorActiveHoverInverted: palette.primary[5]
     }
   } as GlobalThemeOverrides
 }

--- a/src/runtime/utils/colors.ts
+++ b/src/runtime/utils/colors.ts
@@ -148,8 +148,41 @@ function generateColorTheme (mode: ColorMode = 'light', colors: Colors) {
     Tabs: {
       tabColorSegment: palette.neutral[0]
     },
-    Form: {
-      feedbackPadding: '8px 0px 10px 0px' // Patch
+    Menu: {
+      itemTextColorHorizontalInverted: palette.text[7],
+      itemIconColorHorizontalInverted: palette.text[7],
+
+      itemIconColorHoverHorizontalInverted: palette.text[8],
+      itemTextColorHoverHorizontalInverted: palette.text[8],
+
+      itemTextColorActiveHorizontalInverted: palette.text[9],
+      itemIconColorActiveHorizontalInverted: palette.text[9],
+
+      itemTextColorActiveHoverHorizontalInverted: palette.text[8],
+      itemIconColorActiveHoverHorizontalInverted: palette.text[8],
+
+      itemTextColorChildActiveHorizontalInverted: palette.text[9],
+      itemIconColorChildActiveHorizontalInverted: palette.text[9],
+
+      itemIconColorChildActiveHoverHorizontalInverted: palette.text[8],
+      itemTextColorChildActiveHoverHorizontalInverted: palette.text[8],
+
+      itemTextColorInverted: palette.text[8],
+      itemIconColorInverted: palette.text[8],
+      itemTextColorHoverInverted: palette.text[8],
+      itemIconColorHoverInverted: palette.text[8],
+
+      itemTextColorChildActiveHoverInverted: palette.primary[5],
+      itemTextColorChildActiveInverted: palette.primary[6],
+      itemIconColorChildActiveHoverInverted: palette.primary[5],
+      itemIconColorChildActiveInverted: palette.primary[6],
+
+      arrowColorInverted: palette.text[8],
+      arrowColorHoverInverted: palette.text[8],
+      arrowColorChildActiveInverted: palette.primary[6],
+      arrowColorChildActiveHoverInverted: palette.primary[5],
+      arrowColorActiveInverted: palette.primary[6],
+      arrowColorActiveHoverInverted: palette.primary[5]
     }
   } as GlobalThemeOverrides
 }

--- a/src/runtime/utils/colors.ts
+++ b/src/runtime/utils/colors.ts
@@ -27,8 +27,8 @@ export function generateColorThemes (inputColors?: Partial<Colors>) {
   }
 
   return {
-    light: () => generateColorTheme('light', colors),
-    dark: () => generateColorTheme('dark', colors)
+    light: () => generateColorTheme(colors, 'light'),
+    dark: () => generateColorTheme(colors, 'dark')
   }
 }
 
@@ -48,7 +48,7 @@ function generatePalette (paletteOptions: PaletteOptions) {
   }
 }
 
-function generateColorTheme (mode: ColorMode = 'light', colors: Colors) {
+function generateColorTheme (colors: Colors, mode: ColorMode = 'light') {
   const palette = generatePalette({
     theme: mode,
     primary: colors.primary,
@@ -86,12 +86,12 @@ function generateColorTheme (mode: ColorMode = 'light', colors: Colors) {
 
       bodyColor: palette.neutral[0],
       cardColor: palette.neutral[0],
+      modalColor: palette.neutral[0],
       inputColor: palette.neutral[0],
       inputColorDisabled: palette.neutral[0],
 
       tabColor: palette.neutral[1],
       popoverColor: palette.neutral[1],
-      modalColor: palette.neutral[1],
       tagColor: palette.neutral[1],
       baseColor: palette.neutral[1],
       codeColor: palette.neutral[1],
@@ -106,7 +106,7 @@ function generateColorTheme (mode: ColorMode = 'light', colors: Colors) {
       textColorDisabled: palette.text[7],
       textColor1: palette.text[9],
       textColor2: palette.text[8],
-      textColor3: palette.text[7],
+      textColor3: palette.text[6],
 
       placeholderColor: palette.text[5],
       placeholderColorDisabled: palette.text[5],
@@ -200,9 +200,6 @@ function generateColorTheme (mode: ColorMode = 'light', colors: Colors) {
       arrowColorChildActiveHoverInverted: palette.primary[5],
       arrowColorActiveInverted: palette.primary[6],
       arrowColorActiveHoverInverted: palette.primary[5]
-    },
-    Drawer: {
-      color: palette.neutral[0]
     }
   } as GlobalThemeOverrides
 }

--- a/src/runtime/utils/colors.ts
+++ b/src/runtime/utils/colors.ts
@@ -1,0 +1,172 @@
+import { generate } from '@ant-design/colors'
+import type { GlobalThemeOverrides } from 'naive-ui'
+import type { ColorMode } from '../types'
+
+interface Colors {
+  primary: string;
+  success: string;
+  warning: string;
+  error: string;
+  info: string;
+  neutral: string;
+}
+
+interface PaletteOptions extends Colors {
+  theme: ColorMode;
+}
+
+function generatePalette (paletteOptions: PaletteOptions) {
+  const gray = '#bfbfbf'
+  const theme = paletteOptions.theme === 'light' ? 'default' : 'dark'
+  const neutral = theme === 'default' ? gray : paletteOptions.neutral
+
+  return {
+    primary: generate(paletteOptions.primary, { theme }),
+    success: generate(paletteOptions.success, { theme }),
+    warning: generate(paletteOptions.warning, { theme }),
+    error: generate(paletteOptions.error, { theme }),
+    info: generate(paletteOptions.info, { theme }),
+    neutral: generate(neutral, { theme }),
+    text: generate(gray, { theme })
+  }
+}
+
+function generateColorTheme (mode: ColorMode = 'light', colors: Colors) {
+  const palette = generatePalette({
+    theme: mode,
+    primary: colors.primary,
+    success: colors.success,
+    warning: colors.warning,
+    error: colors.error,
+    info: colors.info,
+    neutral: colors.neutral
+  })
+
+  return {
+    defaults: false,
+
+    common: {
+      primaryColor: palette.primary[6],
+      primaryColorHover: palette.primary[5],
+      primaryColorPressed: palette.primary[7],
+      primaryColorSuppl: palette.primary[8],
+      infoColor: palette.info[6],
+      infoColorHover: palette.info[5],
+      infoColorPressed: palette.info[7],
+      infoColorSuppl: palette.info[8],
+      successColor: palette.success[6],
+      successColorHover: palette.success[5],
+      successColorPressed: palette.success[7],
+      successColorSuppl: palette.success[8],
+      warningColor: palette.warning[6],
+      warningColorHover: palette.warning[5],
+      warningColorPressed: palette.warning[7],
+      warningColorSuppl: palette.warning[8],
+      errorColor: palette.error[6],
+      errorColorHover: palette.error[5],
+      errorColorPressed: palette.error[7],
+      errorColorSuppl: palette.error[8],
+
+      bodyColor: palette.neutral[0],
+      cardColor: palette.neutral[0],
+      inputColor: palette.neutral[0],
+      inputColorDisabled: palette.neutral[0],
+
+      tabColor: palette.neutral[1],
+      popoverColor: palette.neutral[1],
+      modalColor: palette.neutral[1],
+      tagColor: palette.neutral[1],
+      baseColor: palette.neutral[1],
+      codeColor: palette.neutral[1],
+
+      dividerColor: palette.neutral[2],
+      avatarColor: palette.neutral[3],
+      hoverColor: palette.neutral[2],
+      actionColor: palette.neutral[1],
+      borderColor: palette.neutral[2],
+
+      textColorBase: palette.text[9],
+      textColorDisabled: palette.text[6],
+      textColor1: palette.text[8],
+      textColor2: palette.text[7],
+      textColor3: palette.text[6],
+
+      placeholderColor: palette.text[5],
+      placeholderColorDisabled: palette.text[5],
+
+      closeIconColor: palette.neutral[7],
+      closeIconColorHover: palette.neutral[6],
+      closeIconColorPressed: palette.neutral[6],
+      closeColorHover: palette.neutral[2],
+      closeColorPressed: palette.neutral[3],
+
+      clearColor: palette.neutral[7],
+      clearColorHover: palette.neutral[6],
+      clearColorPressed: palette.neutral[6],
+
+      scrollbarColor: palette.neutral[2],
+      scrollbarColorHover: palette.neutral[3],
+
+      progressRailColor: palette.neutral[2],
+      railColor: palette.neutral[2],
+
+      buttonColor2: palette.neutral[1],
+      buttonColor2Hover: palette.neutral[2],
+      buttonColor2Pressed: palette.neutral[3],
+
+      tableColor: palette.neutral[1],
+      tableHeaderColor: palette.neutral[1],
+      tableColorStriped: palette.neutral[1],
+      tableColorHover: palette.neutral[1]
+    },
+    Skeleton: {
+      color: palette.neutral[2],
+      colorEnd: palette.neutral[3]
+    },
+    Tag: {
+      colorBordered: palette.neutral[1]
+    },
+    Tooltip: {
+      color: palette.neutral[1],
+      textColor: palette.text[8]
+    },
+    Slider: {
+      indicatorColor: palette.neutral[1],
+      indicatorTextColor: palette.text[8]
+    },
+    Layout: {
+      siderColor: palette.neutral[0],
+      headerColor: palette.neutral[0],
+      footerColor: palette.neutral[0]
+    },
+    Icon: {
+      color: palette.text[8]
+    },
+    Switch: {
+      railColor: palette.neutral[2]
+    },
+    Tabs: {
+      tabColorSegment: palette.neutral[0]
+    },
+    Form: {
+      feedbackPadding: '8px 0px 10px 0px' // Patch
+    }
+  } as GlobalThemeOverrides
+}
+
+export function generateColorThemes (inputColors?: Partial<Colors>) {
+  const colors = {
+    primary: '#1677ff',
+    success: '#52c41a',
+    warning: '#faad14',
+    error: '#f5222d',
+    info: '#1677ff',
+    neutral: '#71717a',
+    ...inputColors
+  }
+
+  return {
+    light: generateColorTheme('light', colors),
+    dark: generateColorTheme('dark', colors)
+  }
+}

--- a/src/runtime/utils/colors.ts
+++ b/src/runtime/utils/colors.ts
@@ -128,6 +128,12 @@ function generateColorThemeLight (colors: Colors) {
       arrowColorChildActiveHoverInverted: palette.primary[5],
       arrowColorActiveInverted: palette.primary[6],
       arrowColorActiveHoverInverted: palette.primary[5]
+    },
+    Input: {
+      lineHeightTextarea: '1.6' // Patch
+    },
+    Form: {
+      feedbackPadding: '8px 0px 10px 0px' // Patch
     }
   } as GlobalThemeOverrides
 }
@@ -247,6 +253,12 @@ function generateColorThemeDark (colors: Colors) {
     },
     Tabs: {
       tabColorSegment: palette.neutral[0]
+    },
+    Input: {
+      lineHeightTextarea: '1.6' // Patch
+    },
+    Form: {
+      feedbackPadding: '8px 0px 10px 0px' // Patch
     }
   } as GlobalThemeOverrides
 }

--- a/src/runtime/utils/colors.ts
+++ b/src/runtime/utils/colors.ts
@@ -11,8 +11,20 @@ interface Colors {
   neutral: string;
 }
 
-interface PaletteOptions extends Colors {
-  theme: ColorMode;
+function generatePalette (mode: ColorMode, colors: Colors) {
+  const gray = '#bfbfbf'
+  const theme = mode === 'light' ? 'default' : 'dark'
+  const neutral = theme === 'default' ? gray : colors.neutral
+
+  return {
+    primary: generate(colors.primary, { theme }),
+    success: generate(colors.success, { theme }),
+    warning: generate(colors.warning, { theme }),
+    error: generate(colors.error, { theme }),
+    info: generate(colors.info, { theme }),
+    neutral: generate(neutral, { theme }),
+    text: generate(gray, { theme })
+  }
 }
 
 export function generateColorThemes (inputColors?: Partial<Colors>) {
@@ -27,30 +39,168 @@ export function generateColorThemes (inputColors?: Partial<Colors>) {
   }
 
   return {
-    light: () => generateColorTheme(colors, 'light'),
-    dark: () => generateColorTheme(colors, 'dark')
+    light: () => generateColorThemeLight(colors),
+    dark: () => generateColorThemeDark(colors)
   }
 }
 
-function generatePalette (paletteOptions: PaletteOptions) {
-  const gray = '#bfbfbf'
-  const theme = paletteOptions.theme === 'light' ? 'default' : 'dark'
-  const neutral = theme === 'default' ? gray : paletteOptions.neutral
+function generateColorThemeLight (colors: Colors) {
+  const palette = generatePalette('light', {
+    primary: colors.primary,
+    success: colors.success,
+    warning: colors.warning,
+    error: colors.error,
+    info: colors.info,
+    neutral: colors.neutral
+  })
 
   return {
-    primary: generate(paletteOptions.primary, { theme }),
-    success: generate(paletteOptions.success, { theme }),
-    warning: generate(paletteOptions.warning, { theme }),
-    error: generate(paletteOptions.error, { theme }),
-    info: generate(paletteOptions.info, { theme }),
-    neutral: generate(neutral, { theme }),
-    text: generate(gray, { theme })
-  }
+    defaults: false,
+
+    common: {
+      primaryColor: palette.primary[6],
+      primaryColorHover: palette.primary[5],
+      primaryColorPressed: palette.primary[7],
+      primaryColorSuppl: palette.primary[8],
+      infoColor: palette.info[6],
+      infoColorHover: palette.info[5],
+      infoColorPressed: palette.info[7],
+      infoColorSuppl: palette.info[8],
+      successColor: palette.success[6],
+      successColorHover: palette.success[5],
+      successColorPressed: palette.success[7],
+      successColorSuppl: palette.success[8],
+      warningColor: palette.warning[6],
+      warningColorHover: palette.warning[5],
+      warningColorPressed: palette.warning[7],
+      warningColorSuppl: palette.warning[8],
+      errorColor: palette.error[6],
+      errorColorHover: palette.error[5],
+      errorColorPressed: palette.error[7],
+      errorColorSuppl: palette.error[8],
+
+      bodyColor: palette.neutral[0],
+      cardColor: palette.neutral[0],
+      modalColor: palette.neutral[0],
+      inputColor: palette.neutral[0],
+      inputColorDisabled: palette.neutral[0],
+
+      tabColor: palette.neutral[1],
+      popoverColor: palette.neutral[1],
+      tagColor: palette.neutral[1],
+      baseColor: palette.neutral[1],
+      codeColor: palette.neutral[1],
+
+      dividerColor: palette.neutral[2],
+      avatarColor: palette.neutral[3],
+      hoverColor: palette.neutral[2],
+      actionColor: palette.neutral[1],
+      borderColor: palette.neutral[2],
+
+      textColorBase: palette.text[9],
+      textColorDisabled: palette.text[7],
+      textColor1: palette.text[9],
+      textColor2: palette.text[8],
+      textColor3: palette.text[6],
+
+      placeholderColor: palette.text[5],
+      placeholderColorDisabled: palette.text[5],
+
+      closeIconColor: palette.neutral[7],
+      closeIconColorHover: palette.neutral[6],
+      closeIconColorPressed: palette.neutral[6],
+      closeColorHover: palette.neutral[2],
+      closeColorPressed: palette.neutral[3],
+
+      clearColor: palette.neutral[7],
+      clearColorHover: palette.neutral[6],
+      clearColorPressed: palette.neutral[6],
+
+      scrollbarColor: palette.neutral[2],
+      scrollbarColorHover: palette.neutral[3],
+
+      progressRailColor: palette.neutral[2],
+      railColor: palette.neutral[2],
+
+      buttonColor2: palette.neutral[1],
+      buttonColor2Hover: palette.neutral[2],
+      buttonColor2Pressed: palette.neutral[3],
+
+      tableColor: palette.neutral[1],
+      tableHeaderColor: palette.neutral[1],
+      tableColorStriped: palette.neutral[1],
+      tableColorHover: palette.neutral[1]
+    },
+    Skeleton: {
+      color: palette.neutral[2],
+      colorEnd: palette.neutral[3]
+    },
+    Tag: {
+      colorBordered: palette.neutral[1]
+    },
+    Tooltip: {
+      color: palette.neutral[1],
+      textColor: palette.text[8]
+    },
+    Slider: {
+      indicatorColor: palette.neutral[1],
+      indicatorTextColor: palette.text[8]
+    },
+    Layout: {
+      siderColor: palette.neutral[0],
+      headerColor: palette.neutral[0],
+      footerColor: palette.neutral[0]
+    },
+    Icon: {
+      color: palette.text[8]
+    },
+    Switch: {
+      railColor: palette.neutral[2]
+    },
+    Tabs: {
+      tabColorSegment: palette.neutral[0]
+    },
+    Menu: {
+      itemTextColorHorizontalInverted: palette.text[7],
+      itemIconColorHorizontalInverted: palette.text[7],
+
+      itemIconColorHoverHorizontalInverted: palette.text[8],
+      itemTextColorHoverHorizontalInverted: palette.text[8],
+
+      itemTextColorActiveHorizontalInverted: palette.text[9],
+      itemIconColorActiveHorizontalInverted: palette.text[9],
+
+      itemTextColorActiveHoverHorizontalInverted: palette.text[8],
+      itemIconColorActiveHoverHorizontalInverted: palette.text[8],
+
+      itemTextColorChildActiveHorizontalInverted: palette.text[9],
+      itemIconColorChildActiveHorizontalInverted: palette.text[9],
+
+      itemIconColorChildActiveHoverHorizontalInverted: palette.text[8],
+      itemTextColorChildActiveHoverHorizontalInverted: palette.text[8],
+
+      itemTextColorInverted: palette.text[8],
+      itemIconColorInverted: palette.text[8],
+      itemTextColorHoverInverted: palette.text[8],
+      itemIconColorHoverInverted: palette.text[8],
+
+      itemTextColorChildActiveHoverInverted: palette.primary[5],
+      itemTextColorChildActiveInverted: palette.primary[6],
+      itemIconColorChildActiveHoverInverted: palette.primary[5],
+      itemIconColorChildActiveInverted: palette.primary[6],
+
+      arrowColorInverted: palette.text[8],
+      arrowColorHoverInverted: palette.text[8],
+      arrowColorChildActiveInverted: palette.primary[6],
+      arrowColorChildActiveHoverInverted: palette.primary[5],
+      arrowColorActiveInverted: palette.primary[6],
+      arrowColorActiveHoverInverted: palette.primary[5]
+    }
+  } as GlobalThemeOverrides
 }
 
-function generateColorTheme (colors: Colors, mode: ColorMode = 'light') {
-  const palette = generatePalette({
-    theme: mode,
+function generateColorThemeDark (colors: Colors) {
+  const palette = generatePalette('dark', {
     primary: colors.primary,
     success: colors.success,
     warning: colors.warning,

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './colors'

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,13 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
+"@ant-design/colors@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@ant-design/colors/-/colors-7.0.2.tgz#c5c753a467ce8d86ba7ca4736d2c01f599bb5492"
+  integrity sha512-7KJkhTiPiLHSu+LmMJnehfJ6242OCxSlR3xHVBecYxnMW8MS/878NXct1GqYARyL59fyeFdKRxXTfvR9SnDgJg==
+  dependencies:
+    "@ctrl/tinycolor" "^3.6.1"
+
 "@antfu/utils@^0.7.7":
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/@antfu/utils/-/utils-0.7.7.tgz#26ea493a831b4f3a85475e7157be02fb4eab51fb"
@@ -346,6 +353,11 @@
   version "0.15.12"
   resolved "https://registry.yarnpkg.com/@css-render/vue3-ssr/-/vue3-ssr-0.15.12.tgz#798d8dffadecd2bf8c80cbaab64e9df10be5626e"
   integrity sha512-AQLGhhaE0F+rwybRCkKUdzBdTEM/5PZBYy+fSYe1T9z9+yxMuV/k7ZRqa4M69X+EI1W8pa4kc9Iq2VjQkZx4rg==
+
+"@ctrl/tinycolor@^3.6.1":
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz#b6c75a56a1947cc916ea058772d666a2c8932f31"
+  integrity sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==
 
 "@emotion/hash@~0.8.0":
   version "0.8.0"


### PR DESCRIPTION
### Context 
Naive UI supports granular and centralized theme customization via `ConfigProvider` component. The module builds upon it to support color mode and device based customization via `NaiveConfig` component. The latter accepts theme configuration via `themeConfig` property either from a prop or App config or Runtime config.

### Issue
When defining a color mode based theme, one should make sure to update all related properties. For example when updating `primary` color, all related states `hover`, `pressed`, `Suppl` should be updated properly. Although the flexibility, this may affect DX especially when customizing the dark theme. 

### Solution
This PR introduces a utility to generate the color mode themes (light & dark) with minimal inputs. It's based on Ant Design palette [generator](https://ant.design/docs/spec/colors#palette-generation-tool) which creates 10 variants of a main color (color-6). By default this utility uses Ant design functional [colors](https://ant.design/docs/spec/colors#functional-color), the main colors can be changed via its argument which are `primary`, `success`, `warning`, `error`, `info` and `neutral` for background, border, etc..

```ts 
// app.config.ts
import { generateColorThemes } from '@bg-dev/nuxt-naiveui/utils'

export default defineAppConfig({
  naiveui: {
    themeConfig: {
      ...generateColorThemes({ primary: '#722ed1' })
    }
  }
})
```