### PR TITLE
chore(NaiveConfig): theme config inputs deprecation

### DIFF
--- a/docs/content/2.components/1.naive-config.md
+++ b/docs/content/2.components/1.naive-config.md
@@ -4,7 +4,7 @@ This component is intended for theme configuration and reactivity, plus setting 
 
 The configuration part is handled via `n-config-provider` naive-ui component through which the theme is overridden based on colorMode and deviceType.
 
-`naive-config` accepts configuration via `themeConfig` prop with fallback to `naiveui.themeConfig` property in `app.config` or `nuxt.config.ts`.
+`naive-config` accepts configuration via `naiveui.themeConfig` property in `app.config`.
 
 ```ts
 interface ThemeConfig {

--- a/src/runtime/components/NaiveConfig.vue
+++ b/src/runtime/components/NaiveConfig.vue
@@ -24,6 +24,7 @@ import {
 
 interface NaiveConfigProps
   extends /* @vue-ignore */ Omit<ConfigProviderProps, 'themeOverrides' | 'theme'> {
+  /** @deprecated since version 1.12.0, instead use `naiveui.themeConfig` in `app.config` */
   themeConfig?: ThemeConfig;
 }
 

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -41,9 +41,7 @@ export interface MenuLinkRoute {
   label: string;
   icon?: string;
   to?: string | RouteLocation;
-  /**
-   * @deprecated since version 1.11.0, please use `to` instead
-   */
+  /** @deprecated since version 1.11.0, instead use `to` */
   path?: string | RouteLocation;
   children?: MenuLinkRoute[];
 }
@@ -55,6 +53,7 @@ export type ColorModePreference = "light" | "dark" | "system";
 export type ColorModeForce = ColorMode | false;
 
 export interface PublicConfig {
+   /** @deprecated since version 1.12.0, instead use `naiveui.themeConfig` in `app.config` */
   themeConfig?: ThemeConfig;
   colorModePreference: ColorModePreference;
   colorModePreferenceCookieName: string;


### PR DESCRIPTION
`NaiveConfig` component accepts theme configuration via themeConfig property either from a prop or App config or Runtime config. 

This PR adds a deprecation warning of the prop input for better code structure and of runtimeConfig input for HMR support. The next major release only allows theme configuration via `app.config`.