### PR TITLE
types:  use `vue-router` route type in navigation components

### DIFF
--- a/playground/layouts/default.vue
+++ b/playground/layouts/default.vue
@@ -38,8 +38,7 @@
 </template>
 
 <script setup lang="ts">
-import type { MenuLinkRoute } from '../../src/module'
-
+import type { MenuLinkRoute } from '#build/types/naiveui.d.ts'
 const navbarRoutes: MenuLinkRoute[] = [
   {
     label: 'Sample, this is a long long label',

--- a/playground/pages/computers/[id].vue
+++ b/playground/pages/computers/[id].vue
@@ -1,3 +1,9 @@
 <template>
-  <h1>ID {{ $route.params.id }}</h1>
+  <h1>ID {{ id }}</h1>
 </template>
+
+<script setup lang="ts">
+import { useRoute } from '#imports'
+
+const { id } = useRoute().params as Record<string, string>
+</script>

--- a/src/module.ts
+++ b/src/module.ts
@@ -15,7 +15,6 @@ import { name, version } from '../package.json'
 import iconifyVitePlugin from './build/iconify'
 import type { PublicConfig } from './runtime/types'
 import { defu } from 'defu'
-export type { TabbarRoute } from './runtime/types'
 
 // Module options TypeScript inteface definition
 export interface ModuleOptions extends PublicConfig { }
@@ -201,14 +200,21 @@ export default defineNuxtModule<ModuleOptions>({
       getContents: () => `
       import {RouteLocationRaw} from '#vue-router'
       export interface MenuLinkRoute {
-            label: string;
-            icon?: string;
-            to?: RouteLocationRaw;
-            /** @deprecated since version 1.11.0, instead use 'to' */
-            path?: RouteLocationRaw;
-            children?: MenuLinkRoute[];
-          }
-      `
+        label: string;
+        icon?: string;
+        to?: RouteLocationRaw;
+        /** @deprecated since version 1.11.0, instead use 'to' */
+        path?: RouteLocationRaw;
+        children?: MenuLinkRoute[];
+      }
+      export interface TabbarRoute {
+        label: string;
+        iconSelected: string;
+        iconUnselected: string;
+        to: RouteLocationRaw;
+        /** @deprecated since version 1.13.1, instead use 'to' */
+        path?: RouteLocationRaw;
+      }`
     })
   }
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -7,14 +7,15 @@ import {
   addImportsDir,
   addComponent,
   addImports,
-  extendViteConfig
+  extendViteConfig,
+  addTypeTemplate
 } from '@nuxt/kit'
 import naive from 'naive-ui'
 import { name, version } from '../package.json'
 import iconifyVitePlugin from './build/iconify'
 import type { PublicConfig } from './runtime/types'
 import { defu } from 'defu'
-export type { TabbarRoute, MenuLinkRoute } from './runtime/types'
+export type { TabbarRoute } from './runtime/types'
 
 // Module options TypeScript inteface definition
 export interface ModuleOptions extends PublicConfig { }
@@ -194,5 +195,20 @@ export default defineNuxtModule<ModuleOptions>({
     if (options.spaLoadingTemplate && typeof nuxt.options.spaLoadingTemplate !== 'string') {
       nuxt.options.spaLoadingTemplate = resolve(runtimeDir, `templates/${options.spaLoadingTemplate.name}.html`)
     }
+
+    addTypeTemplate({
+      filename: 'types/naiveui.d.ts',
+      getContents: () => `
+      import {RouteLocationRaw} from '#vue-router'
+      export interface MenuLinkRoute {
+            label: string;
+            icon?: string;
+            to?: RouteLocationRaw;
+            /** @deprecated since version 1.11.0, instead use 'to' */
+            path?: RouteLocationRaw;
+            children?: MenuLinkRoute[];
+          }
+      `
+    })
   }
 })

--- a/src/runtime/components/NaiveDrawerLink.client.vue
+++ b/src/runtime/components/NaiveDrawerLink.client.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script setup lang="ts">
-import type { MenuLinkRoute } from '../types'
+import type { MenuLinkRoute } from '#build/types/naiveui'
 import { useRouter } from '#imports'
 
 withDefaults(

--- a/src/runtime/components/NaiveLayoutNavbar.vue
+++ b/src/runtime/components/NaiveLayoutNavbar.vue
@@ -59,8 +59,8 @@
 </template>
 
 <script setup lang="ts">
-import type { MenuLinkRoute } from '../types'
 import NaiveDrawerToggle from './internals/NaiveDrawerToggle.vue'
+import type { MenuLinkRoute } from '#build/types/naiveui'
 import { ref, useNaiveDevice } from '#imports'
 
 withDefaults(

--- a/src/runtime/components/NaiveLayoutSidebar.vue
+++ b/src/runtime/components/NaiveLayoutSidebar.vue
@@ -69,8 +69,8 @@
 </template>
 
 <script setup lang="ts">
-import type { MenuLinkRoute } from '../types'
 import NaiveDrawerToggle from './internals/NaiveDrawerToggle.vue'
+import type { MenuLinkRoute } from '#build/types/naiveui'
 import { ref, useNaiveDevice } from '#imports'
 
 withDefaults(

--- a/src/runtime/components/NaiveMenuLink.vue
+++ b/src/runtime/components/NaiveMenuLink.vue
@@ -8,9 +8,9 @@
 <script setup lang="ts">
 import type { Component } from 'vue'
 import type { MenuProps, MenuOption } from 'naive-ui'
-import type { MenuLinkRoute } from '../types'
 import { NuxtLink, NaiveIcon } from '#components'
 import { computed, h, useRouter } from '#imports'
+import type { MenuLinkRoute } from '#build/types/naiveui'
 
 interface NaiveMenuLinkProps
     extends /* @vue-ignore */ Omit<MenuProps, 'options' | 'value'> {

--- a/src/runtime/components/NaiveNavbar.vue
+++ b/src/runtime/components/NaiveNavbar.vue
@@ -111,8 +111,8 @@
 </template>
 
 <script setup lang="ts">
-import type { MenuLinkRoute } from '../types'
 import NaiveDrawerToggle from './internals/NaiveDrawerToggle.vue'
+import type { MenuLinkRoute } from '#build/types/naiveui'
 import {
   ref,
   computed,

--- a/src/runtime/components/NaiveTabbar.vue
+++ b/src/runtime/components/NaiveTabbar.vue
@@ -1,28 +1,28 @@
 <template>
   <div class="outer mobileOrTablet">
     <nuxt-link
-      v-for="tabbarRoute of routes"
-      :key="tabbarRoute.path"
-      :to="tabbarRoute.path"
+      v-for="tabbarRoute of routesC"
+      :key="tabbarRoute.to.path"
+      :to="tabbarRoute.to"
       :style="{ textDecoration: 'none' }"
     >
       <n-button
         text
         :focusable="false"
         aria-label="tabbar-link-item"
-        :type="tabbarRoute.path === route.path ? 'primary' : 'default'"
+        :type="tabbarRoute.to.path === route.path ? 'primary' : 'default'"
       >
         <div class="inner-item">
           <naive-icon
             :name="
-              tabbarRoute.path === route.path
+              tabbarRoute.to.path === route.path
                 ? tabbarRoute.iconSelected
                 : tabbarRoute.iconUnselected
             "
             :size="iconSize"
           />
           <n-text
-            :type="tabbarRoute.path === route.path? 'primary': 'default'"
+            :type="tabbarRoute.to.path === route.path? 'primary': 'default'"
           >
             {{ tabbarRoute.label }}
           </n-text>
@@ -33,11 +33,11 @@
 </template>
 
 <script setup lang="ts">
-import type { TabbarRoute } from '../types'
-import { computed, useRoute, useThemeVars } from '#imports'
+import type { TabbarRoute } from '#build/types/naiveui'
+import { computed, useRoute, useThemeVars, useRouter } from '#imports'
 import { NuxtLink, NaiveIcon } from '#components'
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     routes: TabbarRoute[];
     iconSize?: number | string;
@@ -50,6 +50,15 @@ withDefaults(
 
 const naiveTheme = useThemeVars()
 const route = useRoute()
+const router = useRouter()
+
+const routesC = computed(() => props.routes.map(r => ({
+  label: r.label,
+  iconSelected: r.iconSelected,
+  iconUnselected: r.iconUnselected,
+  to: router.resolve(r.to ?? r.path)
+})))
+
 const backgroundColor = computed(() => naiveTheme.value.bodyColor)
 </script>
 

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -19,26 +19,6 @@ export interface TabbarRoute {
   path: string;
 }
 
-// https://github.com/vuejs/router/blob/main/packages/router/src/types/index.ts
-interface RouteLocation {
-  force?: boolean;
-  hash?: string;
-  name?: string | symbol;
-  params?: Record<string, any>;
-  path?: string;
-  query?: Record<string, any>;
-  replace?: boolean;
-}
-
-export interface MenuLinkRoute {
-  label: string;
-  icon?: string;
-  to?: string | RouteLocation;
-  /** @deprecated since version 1.11.0, instead use `to` */
-  path?: string | RouteLocation;
-  children?: MenuLinkRoute[];
-}
-
 export type ColorMode = "light" | "dark";
 
 export type ColorModePreference = "light" | "dark" | "system";
@@ -57,7 +37,7 @@ type SpaLoadingTemplatesName =
   | "plane-fold"
   | "plane-wave"
   | "plane-rotate";
-  
+
 export interface PublicConfig {
   /** @deprecated since version 1.12.0, instead use `naiveui.themeConfig` in `app.config` */
   themeConfig?: ThemeConfig;

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -12,13 +12,6 @@ export interface ThemeConfig {
   mobile?: Theme | (() => Theme);
 }
 
-export interface TabbarRoute {
-  label: string;
-  iconSelected: string;
-  iconUnselected: string;
-  path: string;
-}
-
 export type ColorMode = "light" | "dark";
 
 export type ColorModePreference = "light" | "dark" | "system";


### PR DESCRIPTION
This PR targets navigation components: `NaiveDrawerLink` `NaiveLayoutNavbar` `NaiveLayoutSidebar` `NaiveMenuLink` `NaiveNavbar` `NaiveTabbar`.

The `routes` and `drawer-routes` props now have a `to` property with the same type as RouteLocation provided by `vue-router`. This avoids potential typecheck issues and provides autocomplete when `typedPages` feature is enabled.

The `MenuLinkRoute` and `TabbarRoute` types needs to be defined on build thus the import path is changed as described below.

```diff
- import {MenuLinkRoute, TabbarRoute} from '@bg-dev/nuxt-naiveui'
+ import {MenuLinkRoute, TabbarRoute} from '#build/types/naiveui'
```