### PR TITLE
build(icons): change default collection url

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -34,7 +34,7 @@ export default defineNuxtModule<ModuleOptions>({
     colorModePreferenceCookieName: 'naive_color_mode_preference',
     iconSize: 20,
     iconDownload: false,
-    iconCollectionsUrl: 'https://iconify-icon-sets.vercel.app',
+    iconCollectionsUrl: 'https://iconify-icon-sets.netlify.app',
     themeConfig: {}
   },
 


### PR DESCRIPTION
Context: https://nuxt-naiveui.bg.tn/components/naive-icon#offline

This PR changes the default icons collection URL from Vercel to Netlify to go around the network limitation in China. The active Vercel endpoint will not be shut down at the moment, however please make sure to update the module.

Vercel
![image](https://github.com/becem-gharbi/nuxt-naiveui/assets/99251251/d8e9ef49-c196-4071-84d6-968759b1d769)

Netlify
![image](https://github.com/becem-gharbi/nuxt-naiveui/assets/99251251/ae0ab493-e497-4453-83a2-59c3361a657c)


