### PR TITLE
fix(NaiveNavbar): correctly center horizontal menu

### DIFF
--- a/src/runtime/components/NaiveNavbar.vue
+++ b/src/runtime/components/NaiveNavbar.vue
@@ -64,6 +64,9 @@
         :inverted="menuInverted"
         mode="horizontal"
         :routes="routes"
+        :style="{
+          justifyContent: menuPlacement
+        }"
       />
     </div>
 


### PR DESCRIPTION
On the `NaiveNavbar` setting `menu-placement` prop to `center` should center the horizontal menu relative to the viewport.

**Current**
![image](https://github.com/becem-gharbi/nuxt-naiveui/assets/99251251/e14e65f5-0425-4104-8e5b-89a5c25de6ec)

**Modified**

![image](https://github.com/becem-gharbi/nuxt-naiveui/assets/99251251/086022f4-6ce8-41b8-becb-42797825034d)
