### PR TITLE
fix: export types

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/types.d.ts",
+      "types": "./dist/module.d.ts",
       "import": "./dist/module.mjs",
       "require": "./dist/module.cjs"
     },
@@ -23,7 +23,7 @@
     }
   },
   "main": "./dist/module.cjs",
-  "types": "./dist/types.d.ts",
+  "types": "./dist/module.d.ts",
   "files": [
     "dist"
   ],

--- a/src/module.ts
+++ b/src/module.ts
@@ -16,6 +16,10 @@ import iconifyVitePlugin from './build/iconify'
 import type { PublicConfig } from './runtime/types'
 import { mergeThemeConfig } from './runtime/themes/merge'
 
+export type {
+  ThemeConfig,
+} from './runtime/types'
+
 // Module options TypeScript inteface definition
 export interface ModuleOptions extends PublicConfig { }
 


### PR DESCRIPTION
at least `ThemeConfig` should be exported. 

I think you should use module.d.ts as entry for types. so all exported stuff there is also exported to the package. i dont see any need to separate that :smiley: 